### PR TITLE
Header on mobile

### DIFF
--- a/css/osw.css
+++ b/css/osw.css
@@ -29,6 +29,15 @@ body {
     font-weight: 700;
 }
 
+@media (max-width: 767px) {
+    .header h1 {
+        font-size: 2em;
+    }
+    .header h3 {
+        font-size: 1.5em;
+    }
+}
+
 /* Custom Button Styles */
 
 .btn-dark {


### PR DESCRIPTION
The fonts of the header will change to a smaller size if the screen size is under 767px
